### PR TITLE
Fix Redis Docker Container Configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
       - scorify-redis:/data
     ports:
       - 6379:6379
-    command: redis-server --requirepass $REDIS_PASSWORD
+    command: redis-server --requirepass $REDIS_PASSWORD --port $REDIS_PORT
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+      REDIS_PORT: ${REDIS_PORT}
   postgres:
     container_name: scorify-db
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - scorify-redis:/data
     ports:
       - 6379:6379
-    env_file: .env
+    command: redis-server --requirepass $REDIS_PASSWORD
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
   postgres:
     container_name: scorify-db
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - scorify-redis:/data
     ports:
-      - 6379:6379
+      - ${REDIS_PORT}:${REDIS_PORT}
     command: redis-server --requirepass $REDIS_PASSWORD --port $REDIS_PORT
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD}


### PR DESCRIPTION
Remove use of `.env` env_file, use direct environment variables, and require auth

Also include redis port in config

Also port forward `REDIS_PORT`