### PR TITLE
Implement Object Caching into Resolvers

### DIFF
--- a/pkg/cache/latest_round.go
+++ b/pkg/cache/latest_round.go
@@ -14,7 +14,7 @@ const (
 )
 
 func PublishLatestRound(ctx context.Context, redisClient *redis.Client, entRound *ent.Round) (*redis.IntCmd, error) {
-	err := SetObject(ctx, redisClient, LatestRoundObjectKey, entRound, 0)
+	err := SetLatestRound(ctx, redisClient, entRound)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/objects.go
+++ b/pkg/cache/objects.go
@@ -104,3 +104,10 @@ func GetRound(ctx context.Context, redisClient *redis.Client, entClient *ent.Cli
 
 	return entRound, nil
 }
+
+func GetLatestRound(ctx context.Context, redisClient *redis.Client) (*ent.Round, bool) {
+	var entRound *ent.Round
+	ok := GetObject(ctx, redisClient, LatestRoundObjectKey, entRound)
+
+	return entRound, ok
+}

--- a/pkg/cache/objects.go
+++ b/pkg/cache/objects.go
@@ -56,7 +56,7 @@ func getObject(ctx context.Context, redisClient *redis.Client, key ObjectKey, ob
 }
 
 func GetUser(ctx context.Context, redisClient *redis.Client, entClient *ent.Client, userID uuid.UUID) (*ent.User, error) {
-	var entUser *ent.User
+	entUser := &ent.User{}
 	if getObject(ctx, redisClient, getUserObjectKey(userID), entUser) {
 		return entUser, nil
 	}
@@ -79,7 +79,7 @@ func SetUser(ctx context.Context, redisClient *redis.Client, entUser *ent.User) 
 }
 
 func GetRound(ctx context.Context, redisClient *redis.Client, entClient *ent.Client, roundID uuid.UUID) (*ent.Round, error) {
-	var entRound *ent.Round
+	entRound := &ent.Round{}
 	if getObject(ctx, redisClient, getRoundObjectKey(roundID), entRound) {
 		return entRound, nil
 	}
@@ -106,7 +106,7 @@ func SetRound(ctx context.Context, redisClient *redis.Client, entRound *ent.Roun
 }
 
 func GetLatestRound(ctx context.Context, redisClient *redis.Client) (*ent.Round, bool) {
-	var entRound *ent.Round
+	entRound := &ent.Round{}
 	ok := getObject(ctx, redisClient, LatestRoundObjectKey, entRound)
 
 	return entRound, ok
@@ -117,10 +117,8 @@ func SetLatestRound(ctx context.Context, redisClient *redis.Client, entRound *en
 }
 
 func GetScoreboard(ctx context.Context, redisClient *redis.Client) (*model.Scoreboard, bool) {
-	var entScoreboard *model.Scoreboard
-	ok := getObject(ctx, redisClient, ScoreboardObjectKey, entScoreboard)
-
-	return entScoreboard, ok
+	scoreboard := &model.Scoreboard{}
+	return scoreboard, getObject(ctx, redisClient, ScoreboardObjectKey, scoreboard)
 }
 
 func SetScoreboard(ctx context.Context, redisClient *redis.Client, scoreboard *model.Scoreboard) error {

--- a/pkg/cache/objects.go
+++ b/pkg/cache/objects.go
@@ -109,7 +109,7 @@ func GetLatestRound(ctx context.Context, redisClient *redis.Client) (*ent.Round,
 }
 
 func SetLatestRound(ctx context.Context, redisClient *redis.Client, entRound *ent.Round) error {
-	return setObject(ctx, redisClient, LatestRoundObjectKey, entRound, long)
+	return setObject(ctx, redisClient, LatestRoundObjectKey, entRound, forever)
 }
 
 func GetScoreboard(ctx context.Context, redisClient *redis.Client) (*model.Scoreboard, bool) {
@@ -120,5 +120,5 @@ func GetScoreboard(ctx context.Context, redisClient *redis.Client) (*model.Score
 }
 
 func SetScoreboard(ctx context.Context, redisClient *redis.Client, scoreboard *model.Scoreboard) error {
-	return setObject(ctx, redisClient, ScoreboardObjectKey, scoreboard, long)
+	return setObject(ctx, redisClient, ScoreboardObjectKey, scoreboard, forever)
 }

--- a/pkg/cache/scoreboard_update.go
+++ b/pkg/cache/scoreboard_update.go
@@ -18,8 +18,7 @@ func PublishScoreboardUpdate(ctx context.Context, redisClient *redis.Client, sco
 	if err != nil {
 		return nil, err
 	}
-
-	err = SetObject(ctx, redisClient, ScoreboardObjectKey, scoreboardUpdate, 0)
+	err = SetScoreboard(ctx, redisClient, scoreboardUpdate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -175,10 +175,9 @@ func (e *Client) loopRoundRunner() error {
 		logrus.WithError(err).Error("failed to create new round")
 		return nil
 	}
-
-	err = cache.SetObject(roundCtx, e.redis, cache.GetRoundObjectKey(entRound.ID), entRound, 0)
+	err = cache.SetRound(roundCtx, e.redis, entRound)
 	if err != nil {
-		logrus.WithError(err).Error("failed to set round object")
+		logrus.WithError(err).Error("failed to set round")
 		return err
 	}
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1370,10 +1370,9 @@ func (r *queryResolver) Config(ctx context.Context, id uuid.UUID) (*ent.CheckCon
 
 // Scoreboard is the resolver for the scoreboard field.
 func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scoreboard, error) {
-	scoreboard := &model.Scoreboard{}
-
 	if round == nil {
-		if cache.GetObject(ctx, r.Redis, cache.ScoreboardObjectKey, scoreboard) {
+		scoreboard, ok := cache.GetScoreboard(ctx, r.Redis)
+		if ok {
 			return scoreboard, nil
 		}
 
@@ -1382,7 +1381,7 @@ func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scor
 			return nil, err
 		}
 
-		err = cache.SetObject(ctx, r.Redis, cache.ScoreboardObjectKey, scoreboard, 0)
+		err = cache.SetScoreboard(ctx, r.Redis, scoreboard)
 		if err != nil {
 			return nil, err
 		}
@@ -1390,7 +1389,8 @@ func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scor
 		return scoreboard, nil
 	}
 
-	if cache.GetObject(ctx, r.Redis, cache.GetScoreboardObjectKey(*round), scoreboard) {
+	scoreboard, ok := cache.GetScoreboard(ctx, r.Redis)
+	if ok {
 		return scoreboard, nil
 	}
 
@@ -1399,7 +1399,7 @@ func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scor
 		return nil, err
 	}
 
-	err = cache.SetObject(ctx, r.Redis, cache.GetScoreboardObjectKey(*round), scoreboard, 0)
+	err = cache.SetScoreboard(ctx, r.Redis, scoreboard)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1765,8 +1765,8 @@ func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Rou
 	latestRoundChan := make(chan *ent.Round, 1)
 
 	go func() {
-		latestRound := &ent.Round{}
-		if cache.GetObject(ctx, r.Redis, cache.LatestRoundObjectKey, latestRound) {
+		latestRound, ok := cache.GetLatestRound(ctx, r.Redis)
+		if ok {
 			latestRoundChan <- latestRound
 		}
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1609,7 +1609,7 @@ func (r *roundResolver) ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent
 
 // Round is the resolver for the round field.
 func (r *scoreCacheResolver) Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error) {
-	return obj.QueryRound().Only(ctx)
+	return cache.GetRound(ctx, r.Redis, r.Ent, obj.RoundID)
 }
 
 // User is the resolver for the user field.
@@ -1624,7 +1624,7 @@ func (r *statusResolver) Check(ctx context.Context, obj *ent.Status) (*ent.Check
 
 // Round is the resolver for the round field.
 func (r *statusResolver) Round(ctx context.Context, obj *ent.Status) (*ent.Round, error) {
-	return obj.QueryRound().Only(ctx)
+	return cache.GetRound(ctx, r.Redis, r.Ent, obj.RoundID)
 }
 
 // User is the resolver for the user field.

--- a/pkg/static/slices.go
+++ b/pkg/static/slices.go
@@ -1,6 +1,8 @@
 package static
 
-import "slices"
+import (
+	"slices"
+)
 
 func FilterSlice[T any](slice []T, filter func(int, T) bool) []T {
 	filteredSlice := make([]T, 0, len(slice))

--- a/pkg/static/slices.go
+++ b/pkg/static/slices.go
@@ -1,19 +1,21 @@
 package static
 
+import "slices"
+
 func FilterSlice[T any](slice []T, filter func(int, T) bool) []T {
-	var filteredSlice []T
+	filteredSlice := make([]T, 0, len(slice))
 	for i, item := range slice {
 		if filter(i, item) {
 			filteredSlice = append(filteredSlice, item)
 		}
 	}
-	return filteredSlice
+	return slices.Clip(filteredSlice)
 }
 
 func MapSlice[T, U any](slice []T, mapper func(int, T) U) []U {
-	var mappedSlice []U
+	mappedSlice := make([]U, len(slice))
 	for i, item := range slice {
-		mappedSlice = append(mappedSlice, mapper(i, item))
+		mappedSlice[i] = mapper(i, item)
 	}
 	return mappedSlice
 }

--- a/src/components/Admin/Minions/EditMinion.tsx
+++ b/src/components/Admin/Minions/EditMinion.tsx
@@ -401,16 +401,17 @@ function EditMinionChildren({ minion }: editMinionChildrenProps) {
           </TableBody>
         </Table>
       </TableContainer>
-      {statuses.length === limit && (
-        <Button
-          variant='contained'
-          onClick={handleLoadMore}
-          sx={{ mt: "16px" }}
-          fullWidth
-        >
-          Load More Statuses
-        </Button>
-      )}
+      <Button
+        variant='contained'
+        onClick={handleLoadMore}
+        sx={{ mt: "16px" }}
+        disabled={
+          statuses.length >= (summaryData?.minionStatusSummary.total || limit)
+        }
+        fullWidth
+      >
+        Load More Statuses
+      </Button>
     </Box>
   );
 }


### PR DESCRIPTION
Add GetUser function to retrieve user from cache or database

Use cache to retrieve user in resolvers

Refactor cache retrieval for GetRound function

Use cache to retrieve round and user in resolvers

Refactor GetLatestRound function to use cache for retrieving the latest round

Refactor cache retrieval for GetLatestRound function

Refactor get/set Object functions

chore: Refactor cache retrieval for GetLatestRound and GetRound functions, and use cache for retrieving round, user, and scoreboard in resolvers

Refactor cache retrieval for GetLatestRound and GetRound functions, and use cache for retrieving round, user, and scoreboard in resolvers