### PR TITLE
Better Handling when No Data Exists

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1505,9 +1505,11 @@ func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scor
 			return nil, err
 		}
 
-		err = cache.SetLatestScoreboard(ctx, r.Redis, scoreboard)
-		if err != nil {
-			return nil, err
+		if scoreboard.Round.Number != 0 {
+			err = cache.SetLatestScoreboard(ctx, r.Redis, scoreboard)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return scoreboard, nil

--- a/pkg/helpers/scoreboard.go
+++ b/pkg/helpers/scoreboard.go
@@ -21,6 +21,15 @@ func Scoreboard(ctx context.Context, entClient *ent.Client) (*model.Scoreboard, 
 		).
 		First(ctx)
 	if err != nil {
+		rounds, countErr := entClient.Round.Query().Count(ctx)
+		if countErr != nil {
+			return nil, countErr
+		}
+
+		if rounds == 0 {
+			return EmptyScoreboard(ctx, entClient)
+		}
+
 		return nil, err
 	}
 

--- a/src/models/scoreboard.tsx
+++ b/src/models/scoreboard.tsx
@@ -3,8 +3,8 @@ import { Property } from "csstype";
 import { ScoreboardQuery, StatusEnum } from "../graph";
 
 export type ScoreboardData = {
-  top: any[];
-  left: any[];
+  top: (number | null | undefined)[];
+  left: (string | null | undefined)[];
   values: ScoreboardQuery["scoreboard"]["statuses"];
 };
 


### PR DESCRIPTION
more accurate typing of `ScoreboardData`

Implement `EmptyScoreboard` function to generate empty scoreboard

Add `EmptyScoreboard` as default output when no other round exist

Do not cache `EmptyScoreboard` as `latestScoreboard`