### PR TITLE
Allow granular database wipes

### DIFF
--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -196,7 +196,7 @@ type ComplexityRoot struct {
 		UpdateMinion           func(childComplexity int, id uuid.UUID, name *string, deactivated *bool) int
 		UpdateUser             func(childComplexity int, id uuid.UUID, username *string, password *string, number *int) int
 		ValidateCheck          func(childComplexity int, source string, config string) int
-		WipeDatabase           func(childComplexity int) int
+		WipeDatabase           func(childComplexity int, deleteUserCheckConfigurations bool, deleteInjectSubmissions bool, deleteStatusesScoresAndRounds bool, deleteCachedData bool) int
 	}
 
 	Notification struct {
@@ -387,7 +387,7 @@ type MutationResolver interface {
 	SubmitInject(ctx context.Context, injectID uuid.UUID, notes string, files []*graphql.Upload) (*ent.InjectSubmission, error)
 	GradeSubmission(ctx context.Context, submissionID uuid.UUID, rubric model.RubricInput) (*ent.InjectSubmission, error)
 	UpdateMinion(ctx context.Context, id uuid.UUID, name *string, deactivated *bool) (*ent.Minion, error)
-	WipeDatabase(ctx context.Context) (bool, error)
+	WipeDatabase(ctx context.Context, deleteUserCheckConfigurations bool, deleteInjectSubmissions bool, deleteStatusesScoresAndRounds bool, deleteCachedData bool) (bool, error)
 }
 type QueryResolver interface {
 	Me(ctx context.Context) (*ent.User, error)
@@ -1213,7 +1213,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Mutation.WipeDatabase(childComplexity), true
+		args, err := ec.field_Mutation_wipeDatabase_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.WipeDatabase(childComplexity, args["deleteUserCheckConfigurations"].(bool), args["deleteInjectSubmissions"].(bool), args["deleteStatusesScoresAndRounds"].(bool), args["deleteCachedData"].(bool)), true
 
 	case "Notification.message":
 		if e.complexity.Notification.Message == nil {
@@ -2597,6 +2602,48 @@ func (ec *executionContext) field_Mutation_validateCheck_args(ctx context.Contex
 		}
 	}
 	args["config"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_wipeDatabase_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 bool
+	if tmp, ok := rawArgs["deleteUserCheckConfigurations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deleteUserCheckConfigurations"))
+		arg0, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["deleteUserCheckConfigurations"] = arg0
+	var arg1 bool
+	if tmp, ok := rawArgs["deleteInjectSubmissions"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deleteInjectSubmissions"))
+		arg1, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["deleteInjectSubmissions"] = arg1
+	var arg2 bool
+	if tmp, ok := rawArgs["deleteStatusesScoresAndRounds"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deleteStatusesScoresAndRounds"))
+		arg2, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["deleteStatusesScoresAndRounds"] = arg2
+	var arg3 bool
+	if tmp, ok := rawArgs["deleteCachedData"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deleteCachedData"))
+		arg3, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["deleteCachedData"] = arg3
 	return args, nil
 }
 
@@ -8265,7 +8312,7 @@ func (ec *executionContext) _Mutation_wipeDatabase(ctx context.Context, field gr
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().WipeDatabase(rctx)
+			return ec.resolvers.Mutation().WipeDatabase(rctx, fc.Args["deleteUserCheckConfigurations"].(bool), fc.Args["deleteInjectSubmissions"].(bool), fc.Args["deleteStatusesScoresAndRounds"].(bool), fc.Args["deleteCachedData"].(bool))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			roles, err := ec.unmarshalORole2ᚕᚖgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋuserᚐRole(ctx, []interface{}{"admin"})
@@ -8314,6 +8361,17 @@ func (ec *executionContext) fieldContext_Mutation_wipeDatabase(ctx context.Conte
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_wipeDatabase_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -386,5 +386,10 @@ type Mutation {
   updateMinion(id: ID!, name: String, deactivated: Boolean): Minion!
     @hasRole(roles: [admin])
 
-  wipeDatabase: Boolean! @hasRole(roles: [admin])
+  wipeDatabase(
+    deleteUserCheckConfigurations: Boolean!
+    deleteInjectSubmissions: Boolean!
+    deleteStatusesScoresAndRounds: Boolean!
+    deleteCachedData: Boolean!
+  ): Boolean! @hasRole(roles: [admin])
 }

--- a/src/components/Admin/AdminPanel/WipeDatabase.tsx
+++ b/src/components/Admin/AdminPanel/WipeDatabase.tsx
@@ -19,6 +19,13 @@ import { ConfirmModal } from "../..";
 import { useWipeDatabaseMutation } from "../../../graph";
 
 export default function WipeDatabase() {
+  const [deleteUserCheckConfigurations, setDeleteUserCheckConfigurations] =
+    useState(true);
+  const [deleteInjectSubmissions, setDeleteInjectSubmissions] = useState(true);
+  const [deleteStatusesScoresAndRounds, setDeleteStatusesScoresAndRounds] =
+    useState(true);
+  const [deleteCachedData, setDeleteCachedData] = useState(true);
+
   const [open, setOpen] = useState(false);
   const [wipeDatabase] = useWipeDatabaseMutation({
     onCompleted: () => {
@@ -52,28 +59,33 @@ export default function WipeDatabase() {
     },
     {
       resource: "User Check Configurations",
-      action: "delete",
-      color: "red",
+      action: deleteUserCheckConfigurations ? "delete" : "keep",
+      color: deleteUserCheckConfigurations ? "red" : "green",
     },
     {
       resource: "User Inject Submissions",
-      action: "delete",
-      color: "red",
+      action: deleteInjectSubmissions ? "delete" : "keep",
+      color: deleteInjectSubmissions ? "red" : "green",
     },
     {
       resource: "Score Check Statuses",
-      action: "delete",
-      color: "red",
+      action: deleteStatusesScoresAndRounds ? "delete" : "keep",
+      color: deleteStatusesScoresAndRounds ? "red" : "green",
+    },
+    {
+      resource: "Rounds",
+      action: deleteStatusesScoresAndRounds ? "delete" : "keep",
+      color: deleteStatusesScoresAndRounds ? "red" : "green",
     },
     {
       resource: "User Scores",
-      action: "delete",
-      color: "red",
+      action: deleteStatusesScoresAndRounds ? "delete" : "keep",
+      color: deleteStatusesScoresAndRounds ? "red" : "green",
     },
     {
       resource: "All cached data",
-      action: "delete",
-      color: "red",
+      action: deleteCachedData ? "delete" : "keep",
+      color: deleteCachedData ? "red" : "green",
     },
   ];
 

--- a/src/components/Admin/AdminPanel/WipeDatabase.tsx
+++ b/src/components/Admin/AdminPanel/WipeDatabase.tsx
@@ -71,19 +71,7 @@ export default function WipeDatabase() {
       toggle: () => setDeleteInjectSubmissions((prev) => !prev),
     },
     {
-      resource: "Score Check Statuses",
-      action: deleteStatusesScoresAndRounds ? "delete" : "keep",
-      color: deleteStatusesScoresAndRounds ? "red" : "green",
-      toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
-    },
-    {
-      resource: "Rounds",
-      action: deleteStatusesScoresAndRounds ? "delete" : "keep",
-      color: deleteStatusesScoresAndRounds ? "red" : "green",
-      toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
-    },
-    {
-      resource: "User Scores",
+      resource: "Statuses, Scores and Rounds",
       action: deleteStatusesScoresAndRounds ? "delete" : "keep",
       color: deleteStatusesScoresAndRounds ? "red" : "green",
       toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),

--- a/src/components/Admin/AdminPanel/WipeDatabase.tsx
+++ b/src/components/Admin/AdminPanel/WipeDatabase.tsx
@@ -12,6 +12,7 @@ import {
   TableHead,
   TableRow,
   Typography,
+  Tooltip,
 } from "@mui/material";
 import { enqueueSnackbar } from "notistack";
 
@@ -61,31 +62,37 @@ export default function WipeDatabase() {
       resource: "User Check Configurations",
       action: deleteUserCheckConfigurations ? "delete" : "keep",
       color: deleteUserCheckConfigurations ? "red" : "green",
+      toggle: () => setDeleteUserCheckConfigurations((prev) => !prev),
     },
     {
       resource: "User Inject Submissions",
       action: deleteInjectSubmissions ? "delete" : "keep",
       color: deleteInjectSubmissions ? "red" : "green",
+      toggle: () => setDeleteInjectSubmissions((prev) => !prev),
     },
     {
       resource: "Score Check Statuses",
       action: deleteStatusesScoresAndRounds ? "delete" : "keep",
       color: deleteStatusesScoresAndRounds ? "red" : "green",
+      toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
     },
     {
       resource: "Rounds",
       action: deleteStatusesScoresAndRounds ? "delete" : "keep",
       color: deleteStatusesScoresAndRounds ? "red" : "green",
+      toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
     },
     {
       resource: "User Scores",
       action: deleteStatusesScoresAndRounds ? "delete" : "keep",
       color: deleteStatusesScoresAndRounds ? "red" : "green",
+      toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
     },
     {
       resource: "All cached data",
       action: deleteCachedData ? "delete" : "keep",
       color: deleteCachedData ? "red" : "green",
+      toggle: () => setDeleteCachedData((prev) => !prev),
     },
   ];
 
@@ -155,13 +162,47 @@ export default function WipeDatabase() {
                 {databaseChanges.map((change, index) => (
                   <TableRow key={index}>
                     <TableCell size='small' align='center'>
-                      <Typography
-                        variant='body2'
-                        style={{ color: change.color }}
-                        textTransform='uppercase'
-                      >
-                        {change.action}
-                      </Typography>
+                      {change.toggle ? (
+                        <Tooltip
+                          title={
+                            <Box
+                              display='flex'
+                              flexDirection='column'
+                              justifyContent='center'
+                            >
+                              <Typography variant='caption' align='center'>
+                                Click to Toggle
+                              </Typography>
+                              <Typography variant='caption' align='center'>
+                                This only edits what "wipe database" will do
+                              </Typography>
+                            </Box>
+                          }
+                        >
+                          <Button
+                            onClick={change.toggle}
+                            variant='contained'
+                            color={
+                              change.color === "green" ? "success" : "error"
+                            }
+                          >
+                            <Typography
+                              variant='body2'
+                              textTransform='uppercase'
+                            >
+                              {change.action}
+                            </Typography>
+                          </Button>
+                        </Tooltip>
+                      ) : (
+                        <Typography
+                          variant='body2'
+                          style={{ color: change.color }}
+                          textTransform='uppercase'
+                        >
+                          {change.action}
+                        </Typography>
+                      )}
                     </TableCell>
                     <TableCell size='small'>
                       <Typography variant='body2'>{change.resource}</Typography>

--- a/src/components/Admin/AdminPanel/WipeDatabase.tsx
+++ b/src/components/Admin/AdminPanel/WipeDatabase.tsx
@@ -21,10 +21,10 @@ import { useWipeDatabaseMutation } from "../../../graph";
 
 export default function WipeDatabase() {
   const [deleteUserCheckConfigurations, setDeleteUserCheckConfigurations] =
-    useState(true);
-  const [deleteInjectSubmissions, setDeleteInjectSubmissions] = useState(true);
+    useState(false);
+  const [deleteInjectSubmissions, setDeleteInjectSubmissions] = useState(false);
   const [deleteStatusesScoresAndRounds, setDeleteStatusesScoresAndRounds] =
-    useState(true);
+    useState(false);
   const [deleteCachedData, setDeleteCachedData] = useState(true);
 
   const [open, setOpen] = useState(false);
@@ -89,7 +89,7 @@ export default function WipeDatabase() {
       toggle: () => setDeleteStatusesScoresAndRounds((prev) => !prev),
     },
     {
-      resource: "All cached data",
+      resource: "Cached data (recommended)",
       action: deleteCachedData ? "delete" : "keep",
       color: deleteCachedData ? "red" : "green",
       toggle: () => setDeleteCachedData((prev) => !prev),
@@ -97,7 +97,14 @@ export default function WipeDatabase() {
   ];
 
   const handleWipeDatabase = () => {
-    wipeDatabase();
+    wipeDatabase({
+      variables: {
+        deleteCachedData,
+        deleteInjectSubmissions,
+        deleteStatusesScoresAndRounds,
+        deleteUserCheckConfigurations,
+      },
+    });
     setOpen(false);
   };
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -299,6 +299,14 @@ export type MutationValidateCheckArgs = {
   source: Scalars['String']['input'];
 };
 
+
+export type MutationWipeDatabaseArgs = {
+  deleteCachedData: Scalars['Boolean']['input'];
+  deleteInjectSubmissions: Scalars['Boolean']['input'];
+  deleteStatusesScoresAndRounds: Scalars['Boolean']['input'];
+  deleteUserCheckConfigurations: Scalars['Boolean']['input'];
+};
+
 export type Notification = {
   __typename?: 'Notification';
   message: Scalars['String']['output'];
@@ -2030,8 +2038,13 @@ export type MinionStatusSummaryLazyQueryHookResult = ReturnType<typeof useMinion
 export type MinionStatusSummarySuspenseQueryHookResult = ReturnType<typeof useMinionStatusSummarySuspenseQuery>;
 export type MinionStatusSummaryQueryResult = Apollo.QueryResult<MinionStatusSummaryQuery, MinionStatusSummaryQueryVariables>;
 export const WipeDatabaseDocument = gql`
-    mutation WipeDatabase {
-  wipeDatabase
+    mutation WipeDatabase($deleteUserCheckConfigurations: Boolean!, $deleteInjectSubmissions: Boolean!, $deleteStatusesScoresAndRounds: Boolean!, $deleteCachedData: Boolean!) {
+  wipeDatabase(
+    deleteUserCheckConfigurations: $deleteUserCheckConfigurations
+    deleteInjectSubmissions: $deleteInjectSubmissions
+    deleteStatusesScoresAndRounds: $deleteStatusesScoresAndRounds
+    deleteCachedData: $deleteCachedData
+  )
 }
     `;
 export type WipeDatabaseMutationFn = Apollo.MutationFunction<WipeDatabaseMutation, WipeDatabaseMutationVariables>;
@@ -2049,6 +2062,10 @@ export type WipeDatabaseMutationFn = Apollo.MutationFunction<WipeDatabaseMutatio
  * @example
  * const [wipeDatabaseMutation, { data, loading, error }] = useWipeDatabaseMutation({
  *   variables: {
+ *      deleteUserCheckConfigurations: // value for 'deleteUserCheckConfigurations'
+ *      deleteInjectSubmissions: // value for 'deleteInjectSubmissions'
+ *      deleteStatusesScoresAndRounds: // value for 'deleteStatusesScoresAndRounds'
+ *      deleteCachedData: // value for 'deleteCachedData'
  *   },
  * });
  */
@@ -2343,7 +2360,12 @@ export type MinionStatusSummaryQueryVariables = Exact<{
 
 export type MinionStatusSummaryQuery = { __typename?: 'Query', minionStatusSummary: { __typename?: 'MinionStatusSummary', total: number, up: number, down: number, unknown: number } };
 
-export type WipeDatabaseMutationVariables = Exact<{ [key: string]: never; }>;
+export type WipeDatabaseMutationVariables = Exact<{
+  deleteUserCheckConfigurations: Scalars['Boolean']['input'];
+  deleteInjectSubmissions: Scalars['Boolean']['input'];
+  deleteStatusesScoresAndRounds: Scalars['Boolean']['input'];
+  deleteCachedData: Scalars['Boolean']['input'];
+}>;
 
 
 export type WipeDatabaseMutation = { __typename?: 'Mutation', wipeDatabase: boolean };

--- a/src/graph/schema.graphql
+++ b/src/graph/schema.graphql
@@ -501,8 +501,18 @@ query MinionStatusSummary($minion_id: ID!) {
   }
 }
 
-mutation WipeDatabase {
-  wipeDatabase
+mutation WipeDatabase(
+  $deleteUserCheckConfigurations: Boolean!
+  $deleteInjectSubmissions: Boolean!
+  $deleteStatusesScoresAndRounds: Boolean!
+  $deleteCachedData: Boolean!
+) {
+  wipeDatabase(
+    deleteUserCheckConfigurations: $deleteUserCheckConfigurations
+    deleteInjectSubmissions: $deleteInjectSubmissions
+    deleteStatusesScoresAndRounds: $deleteStatusesScoresAndRounds
+    deleteCachedData: $deleteCachedData
+  )
 }
 
 mutation ValidateCheck($source: String!, $config: String!) {


### PR DESCRIPTION
update `wipeDatabase` mutation

`go generate ./...`

implement selective database wipe

update `wipeDatabase` `schema..graphql` entry

`npm run generate`

make togglable wipes option be based on useState

make a pretty frontend

working database wipes