### PR TITLE
Add options for Statuses Query

### DIFF
--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -221,6 +221,7 @@ type ComplexityRoot struct {
 		Source                  func(childComplexity int, name string) int
 		Sources                 func(childComplexity int) int
 		Statuses                func(childComplexity int, query model.StatusesQueryInput) int
+		Teams                   func(childComplexity int) int
 		Users                   func(childComplexity int) int
 	}
 
@@ -392,6 +393,7 @@ type MutationResolver interface {
 type QueryResolver interface {
 	Me(ctx context.Context) (*ent.User, error)
 	Users(ctx context.Context) ([]*ent.User, error)
+	Teams(ctx context.Context) ([]*ent.User, error)
 	Sources(ctx context.Context) ([]*model.Source, error)
 	Source(ctx context.Context, name string) (*model.Source, error)
 	Checks(ctx context.Context) ([]*ent.Check, error)
@@ -1390,6 +1392,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Statuses(childComplexity, args["query"].(model.StatusesQueryInput)), true
+
+	case "Query.teams":
+		if e.complexity.Query.Teams == nil {
+			break
+		}
+
+		return e.complexity.Query.Teams(childComplexity), true
 
 	case "Query.users":
 		if e.complexity.Query.Users == nil {
@@ -8583,6 +8592,72 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 }
 
 func (ec *executionContext) fieldContext_Query_users(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "username":
+				return ec.fieldContext_User_username(ctx, field)
+			case "role":
+				return ec.fieldContext_User_role(ctx, field)
+			case "number":
+				return ec.fieldContext_User_number(ctx, field)
+			case "create_time":
+				return ec.fieldContext_User_create_time(ctx, field)
+			case "update_time":
+				return ec.fieldContext_User_update_time(ctx, field)
+			case "configs":
+				return ec.fieldContext_User_configs(ctx, field)
+			case "statuses":
+				return ec.fieldContext_User_statuses(ctx, field)
+			case "score_caches":
+				return ec.fieldContext_User_score_caches(ctx, field)
+			case "inject_submissions":
+				return ec.fieldContext_User_inject_submissions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_teams(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_teams(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Teams(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*ent.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚕᚖgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚐUserᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_teams(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -16925,6 +17000,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_users(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "teams":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_teams(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -189,6 +189,7 @@ type ComplexityRoot struct {
 		Login                  func(childComplexity int, username string, password string) int
 		SendGlobalNotification func(childComplexity int, message string, typeArg model.NotificationType) int
 		StartEngine            func(childComplexity int) int
+		Statuses               func(childComplexity int, query model.StatusesQueryInput) int
 		StopEngine             func(childComplexity int) int
 		SubmitInject           func(childComplexity int, injectID uuid.UUID, notes string, files []*graphql.Upload) int
 		UpdateCheck            func(childComplexity int, id uuid.UUID, name *string, weight *int, config *string, editableFields []string) int
@@ -371,6 +372,7 @@ type MutationResolver interface {
 	AdminLogin(ctx context.Context, id uuid.UUID) (*model.LoginOutput, error)
 	AdminBecome(ctx context.Context, id uuid.UUID) (*model.LoginOutput, error)
 	ChangePassword(ctx context.Context, oldPassword string, newPassword string) (bool, error)
+	Statuses(ctx context.Context, query model.StatusesQueryInput) ([]*ent.Status, error)
 	CreateCheck(ctx context.Context, name string, source string, weight int, config string, editableFields []string) (*ent.Check, error)
 	UpdateCheck(ctx context.Context, id uuid.UUID, name *string, weight *int, config *string, editableFields []string) (*ent.Check, error)
 	DeleteCheck(ctx context.Context, id uuid.UUID) (bool, error)
@@ -1130,6 +1132,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.StartEngine(childComplexity), true
+
+	case "Mutation.statuses":
+		if e.complexity.Mutation.Statuses == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_statuses_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.Statuses(childComplexity, args["query"].(model.StatusesQueryInput)), true
 
 	case "Mutation.stopEngine":
 		if e.complexity.Mutation.StopEngine == nil {
@@ -2359,6 +2373,21 @@ func (ec *executionContext) field_Mutation_sendGlobalNotification_args(ctx conte
 		}
 	}
 	args["type"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_statuses_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.StatusesQueryInput
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg0, err = ec.unmarshalNStatusesQueryInput2githubᚗcomᚋscorifyᚋscorifyᚋpkgᚋgraphᚋmodelᚐStatusesQueryInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg0
 	return args, nil
 }
 
@@ -6779,6 +6808,109 @@ func (ec *executionContext) fieldContext_Mutation_changePassword(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_changePassword_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_statuses(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_statuses(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().Statuses(rctx, fc.Args["query"].(model.StatusesQueryInput))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.IsAuthenticated == nil {
+				return nil, errors.New("directive isAuthenticated is not implemented")
+			}
+			return ec.directives.IsAuthenticated(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*ent.Status); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/scorify/scorify/pkg/ent.Status`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*ent.Status)
+	fc.Result = res
+	return ec.marshalNStatus2ᚕᚖgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚐStatusᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_statuses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Status_id(ctx, field)
+			case "error":
+				return ec.fieldContext_Status_error(ctx, field)
+			case "status":
+				return ec.fieldContext_Status_status(ctx, field)
+			case "points":
+				return ec.fieldContext_Status_points(ctx, field)
+			case "check_id":
+				return ec.fieldContext_Status_check_id(ctx, field)
+			case "round_id":
+				return ec.fieldContext_Status_round_id(ctx, field)
+			case "user_id":
+				return ec.fieldContext_Status_user_id(ctx, field)
+			case "create_time":
+				return ec.fieldContext_Status_create_time(ctx, field)
+			case "update_time":
+				return ec.fieldContext_Status_update_time(ctx, field)
+			case "check":
+				return ec.fieldContext_Status_check(ctx, field)
+			case "round":
+				return ec.fieldContext_Status_round(ctx, field)
+			case "user":
+				return ec.fieldContext_Status_user(ctx, field)
+			case "minion":
+				return ec.fieldContext_Status_minion(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Status", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_statuses_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -16755,6 +16887,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "changePassword":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_changePassword(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "statuses":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_statuses(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -289,6 +289,7 @@ type Subscription {
 type Query {
   me: User
   users: [User!]! @hasRole(roles: [admin])
+  teams: [User!]!
 
   sources: [Source!]!
   source(name: String!): Source!

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -321,6 +321,7 @@ type Mutation {
   adminBecome(id: ID!): LoginOutput! @hasRole(roles: [admin])
   changePassword(oldPassword: String!, newPassword: String!): Boolean!
     @isAuthenticated
+  statuses(query: StatusesQueryInput!): [Status!]! @isAuthenticated
 
   createCheck(
     name: String!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -349,6 +349,11 @@ func (r *mutationResolver) ChangePassword(ctx context.Context, oldPassword strin
 	return err == nil, err
 }
 
+// Statuses is the resolver for the statuses field.
+func (r *mutationResolver) Statuses(ctx context.Context, query model.StatusesQueryInput) ([]*ent.Status, error) {
+	panic(fmt.Errorf("not implemented: Statuses - statuses"))
+}
+
 // CreateCheck is the resolver for the createCheck field.
 func (r *mutationResolver) CreateCheck(ctx context.Context, name string, source string, weight int, config string, editableFields []string) (*ent.Check, error) {
 	tx, err := r.Ent.Tx(ctx)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1492,6 +1492,14 @@ func (r *queryResolver) Users(ctx context.Context) ([]*ent.User, error) {
 	return r.Ent.User.Query().All(ctx)
 }
 
+// Teams is the resolver for the teams field.
+func (r *queryResolver) Teams(ctx context.Context) ([]*ent.User, error) {
+	return r.Ent.User.Query().
+		Where(
+			user.RoleEQ(user.RoleUser),
+		).All(ctx)
+}
+
 // Sources is the resolver for the sources field.
 func (r *queryResolver) Sources(ctx context.Context) ([]*model.Source, error) {
 	var checkSources []*model.Source

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,7 +5,7 @@ import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 import { CircularProgress } from "@mui/material";
 import { enqueueSnackbar } from "notistack";
 
-import { Admin, Error, Main, User } from "./components";
+import { Admin, Authenticated, Error, Main, User } from "./components";
 import { AuthContext } from "./components/Context/AuthProvider";
 import {
   useEngineStateSubscription,
@@ -94,16 +94,21 @@ export function Router({ theme, setTheme, apolloClient }: props) {
           element: <LazyComponent element={<Login />} />,
         },
         {
-          path: "me",
-          element: <LazyComponent element={<Me />} />,
-        },
-        {
-          path: "password",
-          element: <LazyComponent element={<ChangePassword />} />,
-        },
-        {
-          path: "status",
-          element: <LazyComponent element={<Statuses />} />,
+          element: <LazyComponent element={<Authenticated />} />,
+          children: [
+            {
+              path: "me",
+              element: <LazyComponent element={<Me />} />,
+            },
+            {
+              path: "password",
+              element: <LazyComponent element={<ChangePassword />} />,
+            },
+            {
+              path: "status",
+              element: <LazyComponent element={<Statuses />} />,
+            },
+          ],
         },
         {
           path: "scoreboard",

--- a/src/components/Authenticated.tsx
+++ b/src/components/Authenticated.tsx
@@ -1,0 +1,29 @@
+import { Suspense, useContext, useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+
+import { Loading } from ".";
+import { AuthContext } from "./Context";
+
+export default function User() {
+  const { me, meLoading, meError } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const urlParameters = new URLSearchParams(location.search);
+
+  useEffect(() => {
+    if (meError && location.pathname !== "/login") {
+      urlParameters.set("next", location.pathname);
+      navigate(`/login?${urlParameters.toString()}`);
+    }
+  }, [meError, navigate]);
+
+  if (!me || meLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <Outlet />
+    </Suspense>
+  );
+}

--- a/src/components/Core/Drawer.tsx
+++ b/src/components/Core/Drawer.tsx
@@ -97,11 +97,6 @@ export default function DrawerComponent({
             icon={<Scoreboard />}
             onClick={() => navigate("/scoreboard")}
           />
-          <DrawerItem
-            label='Status Query'
-            icon={<QueryBuilder />}
-            onClick={() => navigate("/status")}
-          />
         </List>
         <Divider />
 
@@ -115,20 +110,27 @@ export default function DrawerComponent({
                   onClick={returnToAdmin}
                 />
               ) : (
-                <DrawerItem
-                  label='Logout'
-                  icon={<Logout />}
-                  onClick={() => {
-                    removeCookie("auth");
-                    navigate("/");
-                  }}
-                />
+                <>
+                  <DrawerItem
+                    label='Logout'
+                    icon={<Logout />}
+                    onClick={() => {
+                      removeCookie("auth");
+                      navigate("/");
+                    }}
+                  />
+                  <DrawerItem
+                    label='Change Password'
+                    icon={<Password />}
+                    onClick={() => navigate("/password")}
+                  />
+                  <DrawerItem
+                    label='Status Query'
+                    icon={<QueryBuilder />}
+                    onClick={() => navigate("/status")}
+                  />
+                </>
               )}
-              <DrawerItem
-                label='Change Password'
-                icon={<Password />}
-                onClick={() => navigate("/password")}
-              />
             </List>
             <Divider />
             {me.me.role === "user" && (

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -14,6 +14,7 @@ import MinionGroup from "./Admin/Minions/MinionGroup";
 import CreateUserModal from "./Admin/Users/CreateUserModal";
 import DeleteUserModal from "./Admin/Users/DeleteUserModal";
 import EditUser from "./Admin/Users/EditUser";
+import Authenticated from "./Authenticated";
 import Dropdown from "./Common/Dropdown";
 import FileChip from "./Common/FileChip";
 import FileDrop from "./Common/FileDrop";
@@ -38,6 +39,7 @@ import User from "./User/User";
 
 export {
   Admin,
+  Authenticated,
   ConfigField,
   ConfigureCheck,
   ConfirmModal,

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -160,6 +160,7 @@ export type Mutation = {
   login: LoginOutput;
   sendGlobalNotification: Scalars['Boolean']['output'];
   startEngine: Scalars['Boolean']['output'];
+  statuses: Array<Status>;
   stopEngine: Scalars['Boolean']['output'];
   submitInject: InjectSubmission;
   updateCheck: Check;
@@ -249,6 +250,11 @@ export type MutationLoginArgs = {
 export type MutationSendGlobalNotificationArgs = {
   message: Scalars['String']['input'];
   type: NotificationType;
+};
+
+
+export type MutationStatusesArgs = {
+  query: StatusesQueryInput;
 };
 
 
@@ -1996,6 +2002,52 @@ export type StatusesQueryHookResult = ReturnType<typeof useStatusesQuery>;
 export type StatusesLazyQueryHookResult = ReturnType<typeof useStatusesLazyQuery>;
 export type StatusesSuspenseQueryHookResult = ReturnType<typeof useStatusesSuspenseQuery>;
 export type StatusesQueryResult = Apollo.QueryResult<StatusesQuery, StatusesQueryVariables>;
+export const GetStatusesDocument = gql`
+    mutation GetStatuses($statusesInputQuery: StatusesQueryInput!) {
+  statuses(query: $statusesInputQuery) {
+    id
+    error
+    status
+    create_time
+    update_time
+    check {
+      name
+    }
+    user {
+      username
+    }
+    round {
+      number
+    }
+  }
+}
+    `;
+export type GetStatusesMutationFn = Apollo.MutationFunction<GetStatusesMutation, GetStatusesMutationVariables>;
+
+/**
+ * __useGetStatusesMutation__
+ *
+ * To run a mutation, you first call `useGetStatusesMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGetStatusesMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [getStatusesMutation, { data, loading, error }] = useGetStatusesMutation({
+ *   variables: {
+ *      statusesInputQuery: // value for 'statusesInputQuery'
+ *   },
+ * });
+ */
+export function useGetStatusesMutation(baseOptions?: Apollo.MutationHookOptions<GetStatusesMutation, GetStatusesMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<GetStatusesMutation, GetStatusesMutationVariables>(GetStatusesDocument, options);
+      }
+export type GetStatusesMutationHookResult = ReturnType<typeof useGetStatusesMutation>;
+export type GetStatusesMutationResult = Apollo.MutationResult<GetStatusesMutation>;
+export type GetStatusesMutationOptions = Apollo.BaseMutationOptions<GetStatusesMutation, GetStatusesMutationVariables>;
 export const MinionStatusSummaryDocument = gql`
     query MinionStatusSummary($minion_id: ID!) {
   minionStatusSummary(minion_id: $minion_id) {
@@ -2402,6 +2454,13 @@ export type StatusesQueryVariables = Exact<{
 
 
 export type StatusesQuery = { __typename?: 'Query', statuses: Array<{ __typename?: 'Status', id: string, error?: string | null, status: StatusEnum, create_time: any, update_time: any, check: { __typename?: 'Check', name: string }, user: { __typename?: 'User', username: string }, round: { __typename?: 'Round', number: number } }> };
+
+export type GetStatusesMutationVariables = Exact<{
+  statusesInputQuery: StatusesQueryInput;
+}>;
+
+
+export type GetStatusesMutation = { __typename?: 'Mutation', statuses: Array<{ __typename?: 'Status', id: string, error?: string | null, status: StatusEnum, create_time: any, update_time: any, check: { __typename?: 'Check', name: string }, user: { __typename?: 'User', username: string }, round: { __typename?: 'Round', number: number } }> };
 
 export type MinionStatusSummaryQueryVariables = Exact<{
   minion_id: Scalars['ID']['input'];

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -339,6 +339,7 @@ export type Query = {
   source: Source;
   sources: Array<Source>;
   statuses: Array<Status>;
+  teams: Array<User>;
   users: Array<User>;
 };
 
@@ -2109,6 +2110,54 @@ export function useValidateCheckMutation(baseOptions?: Apollo.MutationHookOption
 export type ValidateCheckMutationHookResult = ReturnType<typeof useValidateCheckMutation>;
 export type ValidateCheckMutationResult = Apollo.MutationResult<ValidateCheckMutation>;
 export type ValidateCheckMutationOptions = Apollo.BaseMutationOptions<ValidateCheckMutation, ValidateCheckMutationVariables>;
+export const StatusesOptionDocument = gql`
+    query StatusesOption {
+  teams {
+    id
+    username
+  }
+  checks {
+    id
+    name
+  }
+  minions {
+    id
+    name
+  }
+}
+    `;
+
+/**
+ * __useStatusesOptionQuery__
+ *
+ * To run a query within a React component, call `useStatusesOptionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStatusesOptionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useStatusesOptionQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useStatusesOptionQuery(baseOptions?: Apollo.QueryHookOptions<StatusesOptionQuery, StatusesOptionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StatusesOptionQuery, StatusesOptionQueryVariables>(StatusesOptionDocument, options);
+      }
+export function useStatusesOptionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StatusesOptionQuery, StatusesOptionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StatusesOptionQuery, StatusesOptionQueryVariables>(StatusesOptionDocument, options);
+        }
+export function useStatusesOptionSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<StatusesOptionQuery, StatusesOptionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<StatusesOptionQuery, StatusesOptionQueryVariables>(StatusesOptionDocument, options);
+        }
+export type StatusesOptionQueryHookResult = ReturnType<typeof useStatusesOptionQuery>;
+export type StatusesOptionLazyQueryHookResult = ReturnType<typeof useStatusesOptionLazyQuery>;
+export type StatusesOptionSuspenseQueryHookResult = ReturnType<typeof useStatusesOptionSuspenseQuery>;
+export type StatusesOptionQueryResult = Apollo.QueryResult<StatusesOptionQuery, StatusesOptionQueryVariables>;
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -2378,3 +2427,8 @@ export type ValidateCheckMutationVariables = Exact<{
 
 
 export type ValidateCheckMutation = { __typename?: 'Mutation', validateCheck: boolean };
+
+export type StatusesOptionQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type StatusesOptionQuery = { __typename?: 'Query', teams: Array<{ __typename?: 'User', id: string, username: string }>, checks: Array<{ __typename?: 'Check', id: string, name: string }>, minions: Array<{ __typename?: 'Minion', id: string, name: string }> };

--- a/src/graph/schema.graphql
+++ b/src/graph/schema.graphql
@@ -492,6 +492,25 @@ query Statuses($statusesInputQuery: StatusesQueryInput!) {
   }
 }
 
+mutation GetStatuses($statusesInputQuery: StatusesQueryInput!) {
+  statuses(query: $statusesInputQuery) {
+    id
+    error
+    status
+    create_time
+    update_time
+    check {
+      name
+    }
+    user {
+      username
+    }
+    round {
+      number
+    }
+  }
+}
+
 query MinionStatusSummary($minion_id: ID!) {
   minionStatusSummary(minion_id: $minion_id) {
     total

--- a/src/graph/schema.graphql
+++ b/src/graph/schema.graphql
@@ -518,3 +518,18 @@ mutation WipeDatabase(
 mutation ValidateCheck($source: String!, $config: String!) {
   validateCheck(source: $source, config: $config)
 }
+
+query StatusesOption {
+  teams {
+    id
+    username
+  }
+  checks {
+    id
+    name
+  }
+  minions {
+    id
+    name
+  }
+}

--- a/src/pages/Statuses.tsx
+++ b/src/pages/Statuses.tsx
@@ -113,6 +113,9 @@ export default function Statuses() {
                   setToTime(date || undefined);
                 }}
               />
+            </Box>
+          </LocalizationProvider>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: 2 }}>
               <TextField
                 label='From Round'
                 type='number'
@@ -127,9 +130,6 @@ export default function Statuses() {
                 onChange={(e) => setToRound(parseInt(e.target.value))}
                 sx={{ flex: 1 }}
               />
-            </Box>
-          </LocalizationProvider>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: 2 }}>
             <TextField
               label='Limit'
               type='number'

--- a/src/pages/Statuses.tsx
+++ b/src/pages/Statuses.tsx
@@ -1,18 +1,20 @@
+import { useEffect, useState } from "react";
+
 import { Box, Button, Container, TextField, Typography } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
+import { enqueueSnackbar } from "notistack";
 
 import { Multiselect } from "../components";
 import {
+  GetStatusesMutation,
   StatusEnum,
   StatusesOptionQuery,
+  useGetStatusesMutation,
   useStatusesOptionQuery,
-  useStatusesQuery,
 } from "../graph";
 import { useURLParam } from "../hooks";
-import { enqueueSnackbar } from "notistack";
-import { useEffect } from "react";
 
 export default function Statuses() {
   const { data, refetch } = useStatusesOptionQuery({
@@ -78,7 +80,10 @@ export default function Statuses() {
     parseInt
   );
 
-  const {} = useStatusesQuery({
+  const [resultStatuses, setResultStatuses] = useState<
+    GetStatusesMutation["statuses"]
+  >([]);
+  const [getStatuses] = useGetStatusesMutation({
     variables: {
       statusesInputQuery: {
         from_time: fromTime,
@@ -92,6 +97,15 @@ export default function Statuses() {
         limit,
         offset,
       },
+    },
+    onCompleted: (data) => {
+      setResultStatuses(data.statuses);
+    },
+    onError: (error) => {
+      enqueueSnackbar("Failed to fetch statuses", {
+        variant: "error",
+      });
+      console.error(error);
     },
   });
 
@@ -221,7 +235,7 @@ export default function Statuses() {
               sx={{ flex: 1 }}
             />
           </Box>
-          <Button variant='contained'>
+          <Button variant='contained' onClick={() => getStatuses()}>
             <Typography>Search</Typography>
           </Button>
         </Box>


### PR DESCRIPTION
Add teams query to graphqls

implement `teams` query

Add `StatusesOptions` query

`npm run generate`

move from/to round text inputs

handle teams, checks, and minions options