### PR TITLE
Audit Log Schema Optimizations

### DIFF
--- a/pkg/ent/audit/audit.go
+++ b/pkg/ent/audit/audit.go
@@ -24,6 +24,8 @@ const (
 	FieldTimestamp = "timestamp"
 	// FieldMessage holds the string denoting the message field in the database.
 	FieldMessage = "message"
+	// FieldUserID holds the string denoting the user_id field in the database.
+	FieldUserID = "user_id"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// Table holds the table name of the audit in the database.
@@ -34,7 +36,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	UserInverseTable = "users"
 	// UserColumn is the table column denoting the user relation/edge.
-	UserColumn = "audit_user"
+	UserColumn = "user_id"
 )
 
 // Columns holds all SQL columns for audit fields.
@@ -44,23 +46,13 @@ var Columns = []string{
 	FieldIP,
 	FieldTimestamp,
 	FieldMessage,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "audits"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"audit_user",
+	FieldUserID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -157,6 +149,11 @@ func ByTimestamp(opts ...sql.OrderTermOption) OrderOption {
 // ByMessage orders the results by the message field.
 func ByMessage(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMessage, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.

--- a/pkg/ent/audit/where.go
+++ b/pkg/ent/audit/where.go
@@ -72,6 +72,11 @@ func Message(v string) predicate.Audit {
 	return predicate.Audit(sql.FieldEQ(FieldMessage, v))
 }
 
+// UserID applies equality check predicate on the "user_id" field. It's identical to UserIDEQ.
+func UserID(v uuid.UUID) predicate.Audit {
+	return predicate.Audit(sql.FieldEQ(FieldUserID, v))
+}
+
 // ActionEQ applies the EQ predicate on the "action" field.
 func ActionEQ(v Action) predicate.Audit {
 	return predicate.Audit(sql.FieldEQ(FieldAction, v))
@@ -265,6 +270,36 @@ func MessageEqualFold(v string) predicate.Audit {
 // MessageContainsFold applies the ContainsFold predicate on the "message" field.
 func MessageContainsFold(v string) predicate.Audit {
 	return predicate.Audit(sql.FieldContainsFold(FieldMessage, v))
+}
+
+// UserIDEQ applies the EQ predicate on the "user_id" field.
+func UserIDEQ(v uuid.UUID) predicate.Audit {
+	return predicate.Audit(sql.FieldEQ(FieldUserID, v))
+}
+
+// UserIDNEQ applies the NEQ predicate on the "user_id" field.
+func UserIDNEQ(v uuid.UUID) predicate.Audit {
+	return predicate.Audit(sql.FieldNEQ(FieldUserID, v))
+}
+
+// UserIDIn applies the In predicate on the "user_id" field.
+func UserIDIn(vs ...uuid.UUID) predicate.Audit {
+	return predicate.Audit(sql.FieldIn(FieldUserID, vs...))
+}
+
+// UserIDNotIn applies the NotIn predicate on the "user_id" field.
+func UserIDNotIn(vs ...uuid.UUID) predicate.Audit {
+	return predicate.Audit(sql.FieldNotIn(FieldUserID, vs...))
+}
+
+// UserIDIsNil applies the IsNil predicate on the "user_id" field.
+func UserIDIsNil() predicate.Audit {
+	return predicate.Audit(sql.FieldIsNull(FieldUserID))
+}
+
+// UserIDNotNil applies the NotNil predicate on the "user_id" field.
+func UserIDNotNil() predicate.Audit {
+	return predicate.Audit(sql.FieldNotNull(FieldUserID))
 }
 
 // HasUser applies the HasEdge predicate on the "user" edge.

--- a/pkg/ent/audit_create.go
+++ b/pkg/ent/audit_create.go
@@ -55,6 +55,20 @@ func (ac *AuditCreate) SetMessage(s string) *AuditCreate {
 	return ac
 }
 
+// SetUserID sets the "user_id" field.
+func (ac *AuditCreate) SetUserID(u uuid.UUID) *AuditCreate {
+	ac.mutation.SetUserID(u)
+	return ac
+}
+
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (ac *AuditCreate) SetNillableUserID(u *uuid.UUID) *AuditCreate {
+	if u != nil {
+		ac.SetUserID(*u)
+	}
+	return ac
+}
+
 // SetID sets the "id" field.
 func (ac *AuditCreate) SetID(u uuid.UUID) *AuditCreate {
 	ac.mutation.SetID(u)
@@ -65,20 +79,6 @@ func (ac *AuditCreate) SetID(u uuid.UUID) *AuditCreate {
 func (ac *AuditCreate) SetNillableID(u *uuid.UUID) *AuditCreate {
 	if u != nil {
 		ac.SetID(*u)
-	}
-	return ac
-}
-
-// SetUserID sets the "user" edge to the User entity by ID.
-func (ac *AuditCreate) SetUserID(id uuid.UUID) *AuditCreate {
-	ac.mutation.SetUserID(id)
-	return ac
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (ac *AuditCreate) SetNillableUserID(id *uuid.UUID) *AuditCreate {
-	if id != nil {
-		ac = ac.SetUserID(*id)
 	}
 	return ac
 }
@@ -227,7 +227,7 @@ func (ac *AuditCreate) createSpec() (*Audit, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.audit_user = &nodes[0]
+		_node.UserID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/ent/audit_update.go
+++ b/pkg/ent/audit_update.go
@@ -10,11 +10,9 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/google/uuid"
 	"github.com/scorify/scorify/pkg/ent/audit"
 	"github.com/scorify/scorify/pkg/ent/predicate"
 	"github.com/scorify/scorify/pkg/ent/schema"
-	"github.com/scorify/scorify/pkg/ent/user"
 )
 
 // AuditUpdate is the builder for updating Audit entities.
@@ -64,34 +62,9 @@ func (au *AuditUpdate) SetNillableMessage(s *string) *AuditUpdate {
 	return au
 }
 
-// SetUserID sets the "user" edge to the User entity by ID.
-func (au *AuditUpdate) SetUserID(id uuid.UUID) *AuditUpdate {
-	au.mutation.SetUserID(id)
-	return au
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (au *AuditUpdate) SetNillableUserID(id *uuid.UUID) *AuditUpdate {
-	if id != nil {
-		au = au.SetUserID(*id)
-	}
-	return au
-}
-
-// SetUser sets the "user" edge to the User entity.
-func (au *AuditUpdate) SetUser(u *User) *AuditUpdate {
-	return au.SetUserID(u.ID)
-}
-
 // Mutation returns the AuditMutation object of the builder.
 func (au *AuditUpdate) Mutation() *AuditMutation {
 	return au.mutation
-}
-
-// ClearUser clears the "user" edge to the User entity.
-func (au *AuditUpdate) ClearUser() *AuditUpdate {
-	au.mutation.ClearUser()
-	return au
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -162,35 +135,6 @@ func (au *AuditUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := au.mutation.Message(); ok {
 		_spec.SetField(audit.FieldMessage, field.TypeString, value)
 	}
-	if au.mutation.UserCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   audit.UserTable,
-			Columns: []string{audit.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := au.mutation.UserIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   audit.UserTable,
-			Columns: []string{audit.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if n, err = sqlgraph.UpdateNodes(ctx, au.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{audit.Label}
@@ -245,34 +189,9 @@ func (auo *AuditUpdateOne) SetNillableMessage(s *string) *AuditUpdateOne {
 	return auo
 }
 
-// SetUserID sets the "user" edge to the User entity by ID.
-func (auo *AuditUpdateOne) SetUserID(id uuid.UUID) *AuditUpdateOne {
-	auo.mutation.SetUserID(id)
-	return auo
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (auo *AuditUpdateOne) SetNillableUserID(id *uuid.UUID) *AuditUpdateOne {
-	if id != nil {
-		auo = auo.SetUserID(*id)
-	}
-	return auo
-}
-
-// SetUser sets the "user" edge to the User entity.
-func (auo *AuditUpdateOne) SetUser(u *User) *AuditUpdateOne {
-	return auo.SetUserID(u.ID)
-}
-
 // Mutation returns the AuditMutation object of the builder.
 func (auo *AuditUpdateOne) Mutation() *AuditMutation {
 	return auo.mutation
-}
-
-// ClearUser clears the "user" edge to the User entity.
-func (auo *AuditUpdateOne) ClearUser() *AuditUpdateOne {
-	auo.mutation.ClearUser()
-	return auo
 }
 
 // Where appends a list predicates to the AuditUpdate builder.
@@ -372,35 +291,6 @@ func (auo *AuditUpdateOne) sqlSave(ctx context.Context) (_node *Audit, err error
 	}
 	if value, ok := auo.mutation.Message(); ok {
 		_spec.SetField(audit.FieldMessage, field.TypeString, value)
-	}
-	if auo.mutation.UserCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   audit.UserTable,
-			Columns: []string{audit.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := auo.mutation.UserIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   audit.UserTable,
-			Columns: []string{audit.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	_node = &Audit{config: auo.config}
 	_spec.Assign = _node.assignValues

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -15,7 +15,7 @@ var (
 		{Name: "ip", Type: field.TypeString, SchemaType: map[string]string{"postgres": "inet"}},
 		{Name: "timestamp", Type: field.TypeTime},
 		{Name: "message", Type: field.TypeString},
-		{Name: "audit_user", Type: field.TypeUUID, Nullable: true},
+		{Name: "user_id", Type: field.TypeUUID, Nullable: true},
 	}
 	// AuditsTable holds the schema information for the "audits" table.
 	AuditsTable = &schema.Table{

--- a/pkg/ent/schema/audit.go
+++ b/pkg/ent/schema/audit.go
@@ -109,6 +109,11 @@ func (Audit) Fields() []ent.Field {
 			StructTag(`json:"message"`).
 			Comment("The message of the audit log").
 			NotEmpty(),
+		field.UUID("user_id", uuid.UUID{}).
+			StructTag(`json:"user_id"`).
+			Comment("The user responsible for the audit log").
+			Optional().
+			Immutable(),
 	}
 }
 
@@ -118,6 +123,8 @@ func (Audit) Edges() []ent.Edge {
 		edge.To("user", User.Type).
 			StructTag(`json:"user"`).
 			Comment("The user responsible for the audit log").
+			Field("user_id").
+			Immutable().
 			Unique(),
 	}
 }

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -80,6 +80,15 @@ type ComplexityRoot struct {
 		UserID    func(childComplexity int) int
 	}
 
+	AuditLogInput struct {
+		Actions  func(childComplexity int) int
+		FromTime func(childComplexity int) int
+		IP       func(childComplexity int) int
+		Message  func(childComplexity int) int
+		ToTime   func(childComplexity int) int
+		Users    func(childComplexity int) int
+	}
+
 	Check struct {
 		Config         func(childComplexity int) int
 		Configs        func(childComplexity int) int
@@ -524,6 +533,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AuditLog.UserID(childComplexity), true
+
+	case "AuditLogInput.actions":
+		if e.complexity.AuditLogInput.Actions == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.Actions(childComplexity), true
+
+	case "AuditLogInput.from_time":
+		if e.complexity.AuditLogInput.FromTime == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.FromTime(childComplexity), true
+
+	case "AuditLogInput.ip":
+		if e.complexity.AuditLogInput.IP == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.IP(childComplexity), true
+
+	case "AuditLogInput.message":
+		if e.complexity.AuditLogInput.Message == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.Message(childComplexity), true
+
+	case "AuditLogInput.to_time":
+		if e.complexity.AuditLogInput.ToTime == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.ToTime(childComplexity), true
+
+	case "AuditLogInput.users":
+		if e.complexity.AuditLogInput.Users == nil {
+			break
+		}
+
+		return e.complexity.AuditLogInput.Users(childComplexity), true
 
 	case "Check.config":
 		if e.complexity.Check.Config == nil {
@@ -3267,6 +3318,252 @@ func (ec *executionContext) fieldContext_AuditLog_user(ctx context.Context, fiel
 				return ec.fieldContext_User_inject_submissions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_from_time(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_from_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FromTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_from_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_to_time(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_to_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ToTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_to_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_actions(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_actions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Actions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]audit.Action)
+	fc.Result = res
+	return ec.marshalOAuditAction2ᚕgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋauditᚐActionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_actions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type AuditAction does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_message(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_message(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Message, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_message(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_ip(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_ip(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IP, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_ip(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLogInput_users(ctx context.Context, field graphql.CollectedField, obj *model.AuditLogInput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLogInput_users(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Users, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]uuid.UUID)
+	fc.Result = res
+	return ec.marshalOID2ᚕgithubᚗcomᚋgoogleᚋuuidᚐUUIDᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLogInput_users(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLogInput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -16068,6 +16365,52 @@ func (ec *executionContext) _AuditLog(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var auditLogInputImplementors = []string{"AuditLogInput"}
+
+func (ec *executionContext) _AuditLogInput(ctx context.Context, sel ast.SelectionSet, obj *model.AuditLogInput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, auditLogInputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AuditLogInput")
+		case "from_time":
+			out.Values[i] = ec._AuditLogInput_from_time(ctx, field, obj)
+		case "to_time":
+			out.Values[i] = ec._AuditLogInput_to_time(ctx, field, obj)
+		case "actions":
+			out.Values[i] = ec._AuditLogInput_actions(ctx, field, obj)
+		case "message":
+			out.Values[i] = ec._AuditLogInput_message(ctx, field, obj)
+		case "ip":
+			out.Values[i] = ec._AuditLogInput_ip(ctx, field, obj)
+		case "users":
+			out.Values[i] = ec._AuditLogInput_users(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var checkImplementors = []string{"Check"}
 
 func (ec *executionContext) _Check(ctx context.Context, sel ast.SelectionSet, obj *ent.Check) graphql.Marshaler {
@@ -21089,6 +21432,73 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalOAuditAction2ᚕgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋauditᚐActionᚄ(ctx context.Context, v interface{}) ([]audit.Action, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]audit.Action, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNAuditAction2githubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋauditᚐAction(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOAuditAction2ᚕgithubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋauditᚐActionᚄ(ctx context.Context, sel ast.SelectionSet, v []audit.Action) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAuditAction2githubᚗcomᚋscorifyᚋscorifyᚋpkgᚋentᚋauditᚐAction(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -77,6 +77,7 @@ type ComplexityRoot struct {
 		Message   func(childComplexity int) int
 		Timestamp func(childComplexity int) int
 		User      func(childComplexity int) int
+		UserID    func(childComplexity int) int
 	}
 
 	Check struct {
@@ -516,6 +517,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AuditLog.User(childComplexity), true
+
+	case "AuditLog.user_id":
+		if e.complexity.AuditLog.UserID == nil {
+			break
+		}
+
+		return e.complexity.AuditLog.UserID(childComplexity), true
 
 	case "Check.config":
 		if e.complexity.Check.Config == nil {
@@ -3155,6 +3163,47 @@ func (ec *executionContext) fieldContext_AuditLog_timestamp(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditLog_user_id(ctx context.Context, field graphql.CollectedField, obj *ent.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditLog_user_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalOID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditLog_user_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -15961,6 +16010,8 @@ func (ec *executionContext) _AuditLog(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "user_id":
+			out.Values[i] = ec._AuditLog_user_id(ctx, field, obj)
 		case "user":
 			field := field
 
@@ -21063,6 +21114,16 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	res := graphql.MarshalBoolean(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, v interface{}) (uuid.UUID, error) {
+	res, err := model.UnmarshalUUID(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, sel ast.SelectionSet, v uuid.UUID) graphql.Marshaler {
+	res := model.MarshalUUID(v)
 	return res
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -10,8 +10,18 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/scorify/scorify/pkg/ent"
+	"github.com/scorify/scorify/pkg/ent/audit"
 	"github.com/scorify/scorify/pkg/ent/status"
 )
+
+type AuditLogInput struct {
+	FromTime *time.Time     `json:"from_time,omitempty"`
+	ToTime   *time.Time     `json:"to_time,omitempty"`
+	Actions  []audit.Action `json:"actions,omitempty"`
+	Message  *string        `json:"message,omitempty"`
+	IP       *string        `json:"ip,omitempty"`
+	Users    []uuid.UUID    `json:"users,omitempty"`
+}
 
 type File struct {
 	ID   uuid.UUID `json:"id"`

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -323,6 +323,15 @@ type AuditLog {
   user: User
 }
 
+type AuditLogInput {
+  from_time: Time
+  to_time: Time
+  actions: [AuditAction!]
+  message: String
+  ip: String
+  users: [ID!]
+}
+
 type Subscription {
   globalNotification: Notification!
   engineState: EngineState!

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -319,6 +319,7 @@ type AuditLog {
   message: String!
   ip: String!
   timestamp: Time!
+  user_id: ID
   user: User
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -42,7 +42,7 @@ func (r *auditLogResolver) IP(ctx context.Context, obj *ent.Audit) (string, erro
 
 // User is the resolver for the user field.
 func (r *auditLogResolver) User(ctx context.Context, obj *ent.Audit) (*ent.User, error) {
-	panic(fmt.Errorf("not implemented: User - user"))
+	return cache.GetUser(ctx, r.Redis, r.Ent, obj.UserID)
 }
 
 // Source is the resolver for the source field.


### PR DESCRIPTION
add user_id field from user edge into audit schema

`go generate ./...`

add `uset_id` field to `AuditLog` gql schema

`go generate ./...`

Implement `User` function on `AuditLog` gql resolver