### PR TITLE
KoTH Status Tooltips and assorted cleanup

### DIFF
--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -172,10 +172,13 @@ type ComplexityRoot struct {
 	}
 
 	KothCheckScore struct {
-		Host func(childComplexity int) int
-		ID   func(childComplexity int) int
-		Name func(childComplexity int) int
-		User func(childComplexity int) int
+		CreateTime func(childComplexity int) int
+		Error      func(childComplexity int) int
+		Host       func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Name       func(childComplexity int) int
+		UpdateTime func(childComplexity int) int
+		User       func(childComplexity int) int
 	}
 
 	KothScoreboard struct {
@@ -1033,6 +1036,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.KothCheck.Weight(childComplexity), true
 
+	case "KothCheckScore.create_time":
+		if e.complexity.KothCheckScore.CreateTime == nil {
+			break
+		}
+
+		return e.complexity.KothCheckScore.CreateTime(childComplexity), true
+
+	case "KothCheckScore.error":
+		if e.complexity.KothCheckScore.Error == nil {
+			break
+		}
+
+		return e.complexity.KothCheckScore.Error(childComplexity), true
+
 	case "KothCheckScore.host":
 		if e.complexity.KothCheckScore.Host == nil {
 			break
@@ -1053,6 +1070,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.KothCheckScore.Name(childComplexity), true
+
+	case "KothCheckScore.update_time":
+		if e.complexity.KothCheckScore.UpdateTime == nil {
+			break
+		}
+
+		return e.complexity.KothCheckScore.UpdateTime(childComplexity), true
 
 	case "KothCheckScore.user":
 		if e.complexity.KothCheckScore.User == nil {
@@ -7139,6 +7163,135 @@ func (ec *executionContext) fieldContext_KothCheckScore_host(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _KothCheckScore_error(ctx context.Context, field graphql.CollectedField, obj *model.KothCheckScore) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_KothCheckScore_error(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Error, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_KothCheckScore_error(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "KothCheckScore",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _KothCheckScore_update_time(ctx context.Context, field graphql.CollectedField, obj *model.KothCheckScore) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_KothCheckScore_update_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdateTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_KothCheckScore_update_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "KothCheckScore",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _KothCheckScore_create_time(ctx context.Context, field graphql.CollectedField, obj *model.KothCheckScore) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_KothCheckScore_create_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreateTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_KothCheckScore_create_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "KothCheckScore",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _KothScoreboard_round(ctx context.Context, field graphql.CollectedField, obj *model.KothScoreboard) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_KothScoreboard_round(ctx, field)
 	if err != nil {
@@ -7248,6 +7401,12 @@ func (ec *executionContext) fieldContext_KothScoreboard_checks(ctx context.Conte
 				return ec.fieldContext_KothCheckScore_user(ctx, field)
 			case "host":
 				return ec.fieldContext_KothCheckScore_host(ctx, field)
+			case "error":
+				return ec.fieldContext_KothCheckScore_error(ctx, field)
+			case "update_time":
+				return ec.fieldContext_KothCheckScore_update_time(ctx, field)
+			case "create_time":
+				return ec.fieldContext_KothCheckScore_create_time(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type KothCheckScore", field.Name)
 		},
@@ -20258,6 +20417,18 @@ func (ec *executionContext) _KothCheckScore(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._KothCheckScore_user(ctx, field, obj)
 		case "host":
 			out.Values[i] = ec._KothCheckScore_host(ctx, field, obj)
+		case "error":
+			out.Values[i] = ec._KothCheckScore_error(ctx, field, obj)
+		case "update_time":
+			out.Values[i] = ec._KothCheckScore_update_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "create_time":
+			out.Values[i] = ec._KothCheckScore_create_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -35,10 +35,13 @@ type InjectSubmissionByUser struct {
 }
 
 type KothCheckScore struct {
-	ID   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
-	User *ent.User `json:"user,omitempty"`
-	Host *string   `json:"host,omitempty"`
+	ID         uuid.UUID `json:"id"`
+	Name       string    `json:"name"`
+	User       *ent.User `json:"user,omitempty"`
+	Host       *string   `json:"host,omitempty"`
+	Error      *string   `json:"error,omitempty"`
+	UpdateTime time.Time `json:"update_time"`
+	CreateTime time.Time `json:"create_time"`
 }
 
 type KothScoreboard struct {

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -280,6 +280,9 @@ type KothCheckScore {
   name: String!
   user: User
   host: String
+  error: String
+  update_time: Time!
+  create_time: Time!
 }
 
 type KothScoreboard {

--- a/src/components/Core/Drawer.tsx
+++ b/src/components/Core/Drawer.tsx
@@ -111,7 +111,7 @@ export default function DrawerComponent({
             onClick={() => navigate("/scoreboard")}
           />
           <DrawerItem
-            label='Koth Scoreboard'
+            label='KoTH Scoreboard'
             icon={<Flag />}
             onClick={() => navigate("/koth-scoreboard")}
           />

--- a/src/components/Scoreboard/KothScoreboard.tsx
+++ b/src/components/Scoreboard/KothScoreboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  Box,
   Paper,
   Table,
   TableBody,
@@ -8,6 +9,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
 
@@ -135,27 +137,43 @@ export default function KothScoreboard({
         <TableBody>
           {scoreboardData.checks.map((check, row) => (
             <TableRow key={`row-${row}`}>
-              <TableCell
-                size='small'
-                onMouseEnter={() => {
-                  setHighlightedColumn(null);
-                  setHighlightedRow(row + 1);
-                  setHighlightedUser(check.user?.number || null);
-                }}
-                sx={{
-                  whiteSpace: "nowrap",
-                  position: "sticky",
-                  left: 0,
-                  backgroundColor:
-                    scoreboardTheme.cell[theme][
-                      highlightedRow === row + 1 ||
-                      highlightedColumn === 0 ||
-                      highlightedUser === check.user?.number
-                        ? "highlighted"
-                        : "plain"
-                    ][check.user ? StatusEnum.Up : StatusEnum.Down],
-                }}
-              />
+              <Tooltip
+                arrow={true}
+                title={
+                  <Box display='flex' flexDirection='column'>
+                    <Typography variant='caption'>
+                      Updated: {check.update_time}
+                    </Typography>{" "}
+                    {check.error && (
+                      <Typography variant='caption'>
+                        Error: {check.error}
+                      </Typography>
+                    )}
+                  </Box>
+                }
+              >
+                <TableCell
+                  size='small'
+                  onMouseEnter={() => {
+                    setHighlightedColumn(null);
+                    setHighlightedRow(row + 1);
+                    setHighlightedUser(check.user?.number || null);
+                  }}
+                  sx={{
+                    whiteSpace: "nowrap",
+                    position: "sticky",
+                    left: 0,
+                    backgroundColor:
+                      scoreboardTheme.cell[theme][
+                        highlightedRow === row + 1 ||
+                        highlightedColumn === 0 ||
+                        highlightedUser === check.user?.number
+                          ? "highlighted"
+                          : "plain"
+                      ][check.user ? StatusEnum.Up : StatusEnum.Down],
+                  }}
+                />
+              </Tooltip>
               <TableCell
                 size='small'
                 onMouseEnter={() => {

--- a/src/components/Scoreboard/Scoreboard.tsx
+++ b/src/components/Scoreboard/Scoreboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  Box,
   Paper,
   Table,
   TableBody,
@@ -128,7 +129,7 @@ export default function Scoreboard({
                   arrow={true}
                   title={
                     value?.__typename ? (
-                      <>
+                      <Box display='flex' flexDirection='column'>
                         <Typography variant='caption'>
                           Updated: {value?.update_time}
                         </Typography>{" "}
@@ -137,7 +138,7 @@ export default function Scoreboard({
                             Error: {value?.error}
                           </Typography>
                         )}
-                      </>
+                      </Box>
                     ) : (
                       <Typography variant='caption'>
                         Status either did not report yet or does not exist

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -175,9 +175,12 @@ export type KothCheck = {
 
 export type KothCheckScore = {
   __typename?: 'KothCheckScore';
+  create_time: Scalars['Time']['output'];
+  error?: Maybe<Scalars['String']['output']>;
   host?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  update_time: Scalars['Time']['output'];
   user?: Maybe<User>;
 };
 
@@ -1509,6 +1512,8 @@ export const KothScoreboardDocument = gql`
         number
       }
       host
+      error
+      update_time
     }
     scores {
       user {
@@ -1567,6 +1572,8 @@ export const KothScoreboardUpdateDocument = gql`
         number
       }
       host
+      error
+      update_time
     }
     scores {
       user {
@@ -2789,12 +2796,12 @@ export type KothScoreboardQueryVariables = Exact<{
 }>;
 
 
-export type KothScoreboardQuery = { __typename?: 'Query', kothScoreboard: { __typename?: 'KothScoreboard', round: { __typename?: 'Round', number: number }, checks: Array<{ __typename?: 'KothCheckScore', id: string, name: string, host?: string | null, user?: { __typename?: 'User', username: string, number?: number | null } | null }>, scores: Array<{ __typename?: 'Score', score: number, user: { __typename?: 'User', username: string, number?: number | null } } | null> } };
+export type KothScoreboardQuery = { __typename?: 'Query', kothScoreboard: { __typename?: 'KothScoreboard', round: { __typename?: 'Round', number: number }, checks: Array<{ __typename?: 'KothCheckScore', id: string, name: string, host?: string | null, error?: string | null, update_time: any, user?: { __typename?: 'User', username: string, number?: number | null } | null }>, scores: Array<{ __typename?: 'Score', score: number, user: { __typename?: 'User', username: string, number?: number | null } } | null> } };
 
 export type KothScoreboardUpdateSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type KothScoreboardUpdateSubscription = { __typename?: 'Subscription', kothScoreboardUpdate: { __typename?: 'KothScoreboard', round: { __typename?: 'Round', number: number }, checks: Array<{ __typename?: 'KothCheckScore', id: string, name: string, host?: string | null, user?: { __typename?: 'User', username: string, number?: number | null } | null }>, scores: Array<{ __typename?: 'Score', score: number, user: { __typename?: 'User', username: string, number?: number | null } } | null> } };
+export type KothScoreboardUpdateSubscription = { __typename?: 'Subscription', kothScoreboardUpdate: { __typename?: 'KothScoreboard', round: { __typename?: 'Round', number: number }, checks: Array<{ __typename?: 'KothCheckScore', id: string, name: string, host?: string | null, error?: string | null, update_time: any, user?: { __typename?: 'User', username: string, number?: number | null } | null }>, scores: Array<{ __typename?: 'Score', score: number, user: { __typename?: 'User', username: string, number?: number | null } } | null> } };
 
 export type ScoreboardQueryVariables = Exact<{
   round?: InputMaybe<Scalars['Int']['input']>;

--- a/src/graph/schema.graphql
+++ b/src/graph/schema.graphql
@@ -248,6 +248,8 @@ query KothScoreboard($round: Int) {
         number
       }
       host
+      error
+      update_time
     }
     scores {
       user {
@@ -272,6 +274,8 @@ subscription KothScoreboardUpdate {
         number
       }
       host
+      error
+      update_time
     }
     scores {
       user {

--- a/src/pages/Scoreboard/KothRound.tsx
+++ b/src/pages/Scoreboard/KothRound.tsx
@@ -83,7 +83,7 @@ export default function KothScoreboardRoundPage({ theme }: props) {
             marginTop: 5,
           }}
         >
-          Koth Scoreboard
+          KoTH Scoreboard
         </Typography>
         <Box
           sx={{
@@ -92,7 +92,7 @@ export default function KothScoreboardRoundPage({ theme }: props) {
           }}
         >
           {data?.kothScoreboard.round.number &&
-            data.kothScoreboard.round.number > 10 ? (
+          data.kothScoreboard.round.number > 10 ? (
             <KeyboardDoubleArrowLeft
               sx={{ cursor: "pointer" }}
               onClick={() => {
@@ -105,7 +105,7 @@ export default function KothScoreboardRoundPage({ theme }: props) {
             <KeyboardDoubleArrowLeft sx={{ visibility: "hidden" }} />
           )}
           {data?.kothScoreboard.round.number &&
-            data.kothScoreboard.round.number > 1 ? (
+          data.kothScoreboard.round.number > 1 ? (
             <KeyboardArrowLeft
               sx={{ cursor: "pointer" }}
               onClick={() => {
@@ -130,8 +130,8 @@ export default function KothScoreboardRoundPage({ theme }: props) {
             </Typography>
           </Box>
           {latestRound &&
-            data?.kothScoreboard.round.number &&
-            latestRound >= data?.kothScoreboard.round.number + 1 ? (
+          data?.kothScoreboard.round.number &&
+          latestRound >= data?.kothScoreboard.round.number + 1 ? (
             <KeyboardArrowRight
               sx={{ cursor: "pointer" }}
               onClick={() => {
@@ -144,8 +144,8 @@ export default function KothScoreboardRoundPage({ theme }: props) {
             <KeyboardArrowRight sx={{ visibility: "hidden" }} />
           )}
           {latestRound &&
-            data?.kothScoreboard.round.number &&
-            latestRound >= data?.kothScoreboard.round.number + 10 ? (
+          data?.kothScoreboard.round.number &&
+          latestRound >= data?.kothScoreboard.round.number + 10 ? (
             <KeyboardDoubleArrowRight
               sx={{ cursor: "pointer" }}
               onClick={() => {

--- a/src/pages/Scoreboard/KothScoreboard.tsx
+++ b/src/pages/Scoreboard/KothScoreboard.tsx
@@ -77,7 +77,7 @@ export default function KothScoreboardPage({ theme }: props) {
             marginTop: 5,
           }}
         >
-          Koth Scoreboard
+          KoTH Scoreboard
         </Typography>
         <Box
           sx={{


### PR DESCRIPTION
update `KothCheckScore` gql schema

Include `CreateTime`, `UpdateTime`, and `Error` in koth models

include `error` and `update_time` in `kothcScoreboard` query and subscription

include tooltip on statuses on `/koth-scoreboard`

proper capitalization of `KoTH`