### PR TITLE
Add `auditLog` mutation to gql schema

### DIFF
--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -23,6 +23,17 @@ type AuditLogInput struct {
 	Users    []uuid.UUID    `json:"users,omitempty"`
 }
 
+type AuditLogQueryInput struct {
+	FromTime *time.Time     `json:"from_time,omitempty"`
+	ToTime   *time.Time     `json:"to_time,omitempty"`
+	Actions  []audit.Action `json:"actions,omitempty"`
+	Message  *string        `json:"message,omitempty"`
+	IP       *string        `json:"ip,omitempty"`
+	Users    []uuid.UUID    `json:"users,omitempty"`
+	Limit    *int           `json:"limit,omitempty"`
+	Offset   *int           `json:"offset,omitempty"`
+}
+
 type File struct {
 	ID   uuid.UUID `json:"id"`
 	Name string    `json:"name"`

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -133,6 +133,17 @@ input StatusesQueryInput {
   offset: Int
 }
 
+input AuditLogQueryInput {
+  from_time: Time
+  to_time: Time
+  actions: [AuditAction!]
+  message: String
+  ip: String
+  users: [ID!]
+  limit: Int
+  offset: Int
+}
+
 type MinionMetrics {
   minion_id: ID!
   timestamp: Time!
@@ -435,6 +446,7 @@ type Mutation {
   changePassword(oldPassword: String!, newPassword: String!): Boolean!
     @isAuthenticated
   statuses(query: StatusesQueryInput!): [Status!]! @isAuthenticated
+  auditLog(query: AuditLogQueryInput!): [AuditLog!]! @hasRole(roles: [admin])
 
   createCheck(
     name: String!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -583,7 +583,7 @@ func (r *mutationResolver) Statuses(ctx context.Context, query model.StatusesQue
 	}
 
 	if query.Limit != nil {
-		entStatusQuery = entStatusQuery.Limit(*query.Limit)
+		entStatusQuery = entStatusQuery.Limit(min(*query.Limit, 200))
 	} else {
 		entStatusQuery = entStatusQuery.Limit(100)
 	}
@@ -617,6 +617,43 @@ func (r *mutationResolver) Statuses(ctx context.Context, query model.StatusesQue
 	}
 
 	return entStatusQuery.Order(ent.Desc(status.FieldUpdateTime)).All(ctx)
+}
+
+// AuditLog is the resolver for the auditLog field.
+func (r *mutationResolver) AuditLog(ctx context.Context, query model.AuditLogQueryInput) ([]*ent.Audit, error) {
+	entAuditQuery := r.Ent.Audit.Query()
+
+	if query.FromTime != nil {
+		entAuditQuery = entAuditQuery.Where(audit.TimestampGTE(*query.FromTime))
+	}
+
+	if query.ToTime != nil {
+		entAuditQuery = entAuditQuery.Where(audit.TimestampLTE(*query.ToTime))
+	}
+
+	if query.Limit != nil {
+		entAuditQuery = entAuditQuery.Limit(min(*query.Limit, 200))
+	} else {
+		entAuditQuery = entAuditQuery.Limit(100)
+	}
+
+	if query.Offset != nil {
+		entAuditQuery = entAuditQuery.Offset(*query.Offset)
+	}
+
+	if len(query.Users) > 0 {
+		entAuditQuery = entAuditQuery.Where(audit.UserIDIn(query.Users...))
+	}
+
+	if len(query.Actions) > 0 {
+		entAuditQuery = entAuditQuery.Where(audit.ActionIn(query.Actions...))
+	}
+
+	if query.IP != nil {
+		entAuditQuery = entAuditQuery.Where(audit.IPEQ(&structs.Inet{IP: net.ParseIP(*query.IP)}))
+	}
+
+	return entAuditQuery.Order(ent.Desc(audit.FieldTimestamp)).All(ctx)
 }
 
 // CreateCheck is the resolver for the createCheck field.


### PR DESCRIPTION
Add `auditLog` mutation to gql schema

`go generate ./...`

implement `AuditLog` mutation resolver