### PR TITLE
Fix inject submissions resolver to filter by inject ID

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -189,7 +189,12 @@ func (r *injectResolver) Submissions(ctx context.Context, obj *ent.Inject) ([]*e
 		return nil, fmt.Errorf("invalid user")
 	}
 
-	entInjectSubmissionQuery := r.Ent.InjectSubmission.Query()
+	entInjectSubmissionQuery := r.Ent.InjectSubmission.Query().
+		Where(
+			injectsubmission.HasInjectWith(
+				inject.IDEQ(obj.ID),
+			),
+		)
 
 	if entUser.Role != user.RoleAdmin {
 		return entInjectSubmissionQuery.Where(


### PR DESCRIPTION
## Summary
- Fixes a bug where the `Submissions` resolver on `injectResolver` was missing a filter for the inject ID
- Previously returned submissions from all injects instead of just the queried inject
- Users could see submissions from other injects, and admins would see all submissions in the database


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the submission query to properly filter and return only submissions associated with the specific inject being accessed, resolving an issue where the query was previously returning unfiltered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->