### PR TITLE
scorify: bump Go in Dockerfile

### DIFF
--- a/Dockerfile.scorify
+++ b/Dockerfile.scorify
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22 AS builder
+FROM docker.io/library/golang:1.24 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum main.go /app/
@@ -6,7 +6,7 @@ COPY pkg /app/pkg
 
 RUN go mod download && go build -o /app/scorify main.go
 
-FROM docker.io/library/golang:1.22
+FROM docker.io/library/golang:1.24
 
 # Copy any custom CA certificates from the host
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates \


### PR DESCRIPTION
Dependabot's https://github.com/Scorify/Scorify/commit/2e1efde002485cebe0befa5642e926e7aef052db bumps the Go toolchain version in `go.mod` to 1.24, which breaks building Scorify (both server and minions) because the Dockerfile still uses Go 1.22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure with a newer Go version for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->