### PR TITLE
fix: harden GraphQL subscriptions (leaks, minion-metrics auth, websocket origin)

### DIFF
--- a/pkg/cmd/server/main.go
+++ b/pkg/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -48,6 +49,19 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
+// allowedOrigins is the single source of truth for both the CORS allow-list
+// and the websocket handshake origin check.
+func allowedOrigins() []string {
+	return []string{
+		fmt.Sprintf("http://%s:%d", config.Domain, config.Port),
+		fmt.Sprintf("https://%s:%d", config.Domain, config.Port),
+		fmt.Sprintf("http://%s:3000", config.Domain),
+		fmt.Sprintf("https://%s:3000", config.Domain),
+		fmt.Sprintf("http://%s:5173", config.Domain),
+		fmt.Sprintf("https://%s:5173", config.Domain),
+	}
+}
+
 func graphqlHandler(entClient *ent.Client, taskRequestChan chan *structs.TaskRequest, taskResponseChan chan *structs.TaskResponse, workerStatusChan chan *structs.WorkerStatus, redisClient *redis.Client, engineClient *engine.Client) gin.HandlerFunc {
 	conf := graph.Config{
 		Resolvers: &graph.Resolver{
@@ -73,7 +87,14 @@ func graphqlHandler(entClient *ent.Client, taskRequestChan chan *structs.TaskReq
 		KeepAlivePingInterval: 10 * time.Second,
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return true
+				origin := r.Header.Get("Origin")
+				// Non-browser clients don't send Origin and can't carry the
+				// victim's ambient cookie, so they aren't a CSWSH vector. Browsers
+				// always send Origin on the handshake; require it to be allow-listed.
+				if origin == "" {
+					return true
+				}
+				return slices.Contains(allowedOrigins(), origin)
 			},
 		},
 	})
@@ -260,17 +281,8 @@ func startWebServer(wg *sync.WaitGroup, entClient *ent.Client, redisClient *redi
 		logrus.WithError(err).Fatal("failed to set trusted proxies")
 	}
 
-	cors_urls := []string{
-		fmt.Sprintf("http://%s:%d", config.Domain, config.Port),
-		fmt.Sprintf("https://%s:%d", config.Domain, config.Port),
-		fmt.Sprintf("http://%s:3000", config.Domain),
-		fmt.Sprintf("https://%s:3000", config.Domain),
-		fmt.Sprintf("http://%s:5173", config.Domain),
-		fmt.Sprintf("https://%s:5173", config.Domain),
-	}
-
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     cors_urls,
+		AllowOrigins:     allowedOrigins(),
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "accept", "origin", "Cache-Control", "X-Requested-With"},
 		AllowCredentials: true,

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2721,11 +2721,26 @@ func (r *statusResolver) Minion(ctx context.Context, obj *ent.Status) (*ent.Mini
 }
 
 // GlobalNotification is the resolver for the globalNotification field.
+// requireAdmin enforces the same check as @hasRole(roles: [admin]) for
+// subscription resolvers. gqlgen only applies field directives through the
+// generated executor, so subscription auth is enforced here in-resolver.
+func requireAdmin(ctx context.Context) error {
+	if entUser, err := auth.Parse(ctx); err == nil && entUser.Role == user.RoleAdmin {
+		return nil
+	}
+	if entAdmin, err := auth.ParseAdmin(ctx); err == nil && entAdmin.Role == user.RoleAdmin {
+		return nil
+	}
+	return fmt.Errorf("invalid permissions; admin role required")
+}
+
 func (r *subscriptionResolver) GlobalNotification(ctx context.Context) (<-chan *model.Notification, error) {
 	notification_chan := make(chan *model.Notification, 1)
 
 	go func() {
 		sub := cache.SubscribeNotification(ctx, r.Redis)
+		defer sub.Close()
+		defer close(notification_chan)
 
 		ch := sub.Channel()
 		for {
@@ -2738,10 +2753,12 @@ func (r *subscriptionResolver) GlobalNotification(ctx context.Context) (<-chan *
 					continue
 				}
 
-				notification_chan <- &notification
+				select {
+				case notification_chan <- &notification:
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
-				close(notification_chan)
-				sub.Close()
 				return
 			}
 		}
@@ -2772,8 +2789,11 @@ func (r *subscriptionResolver) EngineState(ctx context.Context) (<-chan model.En
 		for {
 			select {
 			case msg := <-ch:
-				state := model.EngineState(msg.Payload)
-				engineStateChan <- state
+				select {
+				case engineStateChan <- model.EngineState(msg.Payload):
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
 				return
 			}
@@ -2789,6 +2809,9 @@ func (r *subscriptionResolver) ScoreboardUpdate(ctx context.Context) (<-chan *mo
 
 	go func() {
 		scoreboardSub := cache.SubscribeScoreboardUpdate(ctx, r.Redis)
+		defer scoreboardSub.Close()
+		defer close(scoreboardUpdateChan)
+
 		scoreboardChan := scoreboardSub.Channel()
 
 		for {
@@ -2801,10 +2824,12 @@ func (r *subscriptionResolver) ScoreboardUpdate(ctx context.Context) (<-chan *mo
 					continue
 				}
 
-				scoreboardUpdateChan <- scoreboardUpdate
+				select {
+				case scoreboardUpdateChan <- scoreboardUpdate:
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
-				close(scoreboardUpdateChan)
-				scoreboardSub.Close()
 				return
 			}
 		}
@@ -2819,6 +2844,9 @@ func (r *subscriptionResolver) KothScoreboardUpdate(ctx context.Context) (<-chan
 
 	go func() {
 		kothScoreboardSub := cache.SubscribeKothScoreboardUpdate(ctx, r.Redis)
+		defer kothScoreboardSub.Close()
+		defer close(kothScoreboardUpdateChan)
+
 		kothScoreboardChan := kothScoreboardSub.Channel()
 
 		for {
@@ -2831,10 +2859,12 @@ func (r *subscriptionResolver) KothScoreboardUpdate(ctx context.Context) (<-chan
 					continue
 				}
 
-				kothScoreboardUpdateChan <- kothScoreboardUpdate
+				select {
+				case kothScoreboardUpdateChan <- kothScoreboardUpdate:
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
-				close(kothScoreboardUpdateChan)
-				kothScoreboardSub.Close()
 				return
 			}
 		}
@@ -2845,10 +2875,20 @@ func (r *subscriptionResolver) KothScoreboardUpdate(ctx context.Context) (<-chan
 
 // MinionUpdate is the resolver for the minionUpdate field.
 func (r *subscriptionResolver) MinionUpdate(ctx context.Context) (<-chan *structs.Heartbeat, error) {
+	// Minion metrics (CPU/memory/goroutines/IP) are infrastructure data; restrict
+	// to admins. Enforced in-resolver since gqlgen does not apply @hasRole to
+	// subscription fields without regenerating the executor.
+	if err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	minionUpdateChan := make(chan *structs.Heartbeat, 1)
 
 	go func() {
 		minionUpdateSub := cache.SubscribeMiniontMetrics(ctx, r.Redis)
+		defer minionUpdateSub.Close()
+		defer close(minionUpdateChan)
+
 		minionUpdateSubChan := minionUpdateSub.Channel()
 
 		for {
@@ -2861,10 +2901,12 @@ func (r *subscriptionResolver) MinionUpdate(ctx context.Context) (<-chan *struct
 					continue
 				}
 
-				minionUpdateChan <- minionUpdate
+				select {
+				case minionUpdateChan <- minionUpdate:
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
-				close(minionUpdateChan)
-				minionUpdateSub.Close()
 				return
 			}
 		}
@@ -2878,6 +2920,10 @@ func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Rou
 	latestRoundChan := make(chan *ent.Round, 1)
 
 	go func() {
+		latestRoundSub := cache.SubscribeLatestRound(ctx, r.Redis)
+		defer latestRoundSub.Close()
+		defer close(latestRoundChan)
+
 		latestRound, err := cache.GetLatestRound(ctx, r.Redis, r.Ent)
 		if err != nil {
 			logrus.WithError(err).Error("failed to get latest round")
@@ -2885,7 +2931,6 @@ func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Rou
 			latestRoundChan <- latestRound
 		}
 
-		latestRoundSub := cache.SubscribeLatestRound(ctx, r.Redis)
 		latestRoundSubChan := latestRoundSub.Channel()
 
 		for {
@@ -2898,10 +2943,12 @@ func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Rou
 					continue
 				}
 
-				latestRoundChan <- latestRound
+				select {
+				case latestRoundChan <- latestRound:
+				case <-ctx.Done():
+					return
+				}
 			case <-ctx.Done():
-				close(latestRoundChan)
-				latestRoundSub.Close()
 				return
 			}
 		}


### PR DESCRIPTION
Second batch from the audit — hardening the real-time layer. Two files (`pkg/graph/schema.resolvers.go`, `pkg/cmd/server/main.go`); `go build ./...`, `go vet`, and `gofmt` all pass.

## What & why

| ID | Fix | Impact |
|----|-----|--------|
| **SUB-1** | All 6 subscription resolvers guard the outbound send with a `select { … case <-ctx.Done() }` and clean up via `defer sub.Close()` + `defer close(chan)`. | The send in the message branch was unguarded. On client disconnect gqlgen cancels the ctx and stops draining; when both `<-ch` and `<-ctx.Done()` were ready Go could pick `<-ch`, fill the size-1 buffer, and then block **forever** on the next send — never reaching the cleanup branch. Each stuck subscriber leaked a resolver goroutine, the go-redis PubSub goroutine, and a **Redis connection**. Over a multi-day event with reconnecting scoreboard viewers this trends toward `maxclients` exhaustion. |
| **SUB-2** | `minionUpdate` now requires **admin** (in-resolver `requireAdmin`, mirroring `@hasRole(roles:[admin])`). | It streams infrastructure metrics (CPU / memory / goroutines / minion IP) and was reachable by any anonymous client. Other streams stay **public** to match the intentionally-public `scoreboard`/`kothScoreboard` queries. |
| **SUB-4** | `latestRound` subscribes **before** reading the cached value. | Closes a small fetch-then-subscribe race that could drop a round update published in the gap. |
| **CMD-3** | Websocket `CheckOrigin` validates `Origin` against the CORS allow-list instead of `return true`. | Prevents **cross-site websocket hijacking**: auth is cookie-based, so a browser attaches the victim's cookie on a cross-origin handshake. Extracted `allowedOrigins()` as the single source of truth for CORS + the WS handshake. Empty `Origin` (non-browser clients, which carry no ambient cookie) is still allowed. |

## Notes for review
- **Why in-resolver auth, not a schema directive:** there's no `gqlgen.yml` and directive enforcement lives entirely in the generated `generated.go`; adding `@hasRole` to a subscription field does nothing without a full gqlgen regen. `requireAdmin` uses the exact same `auth.Parse`/`auth.ParseAdmin` + role check as the `HasRole` directive.
- **Auth over websockets works** because `JWTMiddleware` (global, runs on the WS-upgrade GET) sets the user via `Request.WithContext`, and gqlgen derives the subscription connection context from the upgrade request — so `requireAdmin(ctx)` sees the admin. The admin Minions live view (which uses `minionUpdate`) is unaffected.
- **Subscription visibility policy** was confirmed with the maintainer: only `minionUpdate` is restricted; the rest remain public to match the public scoreboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)